### PR TITLE
Do not load testing helpers in development environment.

### DIFF
--- a/lib/betterdoc/containerservice/testing.rb
+++ b/lib/betterdoc/containerservice/testing.rb
@@ -1,5 +1,7 @@
-require_relative "testing/integration_test_helper"
+if Rails.env.test?
+  require_relative "testing/integration_test_helper"
 
-class ActionDispatch::IntegrationTest
-  include Betterdoc::Containerservice::IntegrationTestHelper
+  class ActionDispatch::IntegrationTest
+    include Betterdoc::Containerservice::IntegrationTestHelper
+  end
 end


### PR DESCRIPTION
Gem needs to be added to the development group in Gemfile in case you need
helpers for starting ES test cluster for example. That was also loading
testing helpers including webmock initialization which blocks all
external requests :)